### PR TITLE
fix: set logConsole correctly

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,8 +3,7 @@
 
 const isProduction = process.env.NODE_ENV === "production" ? true : false;
 const logLevel = process.env.logLevel || (isProduction && "error") || "info";
-const logConsole =
-  process.env.logConsole == "true" || (isProduction ? false : true);
+const logConsole = isProduction ? false : (process.env.logConsole !== "false");
 
 const config = {
   eventLogger: {


### PR DESCRIPTION
Issue - logConsole was not working if it was set to false.
Fix - logConsole will true if env.logConsole is true or undefined/null and false if false or isProduction true. 
